### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SuperID SDK enables developers to integrate face-login function into their nativ
 ## Getting Started
 
 1. Register as a SuperID developer at our website: [SuperID.me](http://superid.me)
-2. Download the SDK for iOS or via Cocoapods by adding the 'SuperID' pods.
+2. Download the SDK for iOS or via CocoaPods by adding the 'SuperID' pods.
 3. Creat a SuperID App in our Super Deveoper Center website: [Deveoper Center](https://center.superid.me/developer/login/).
 4. Check-out the tutorials available online at: [Getting Started](http://superid.me/document/ios_quickstart.html).
 6. Start coding! Visit [SuperID Doc](http://superid.me/document/ios_quickstart.html) for tutorials and reference documentation.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
